### PR TITLE
Implement tarot API spec and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ GET /tarot/last → returns the last dealt spread/analysis
 
 GET / → health text
 
+## Verification
+
+### Local
+
+```bash
+BASE="http://localhost:8787"
+./scripts/test_endpoints.sh "$BASE"
+```
+
+### Production
+
+```bash
+BASE="https://divia.pegasuswingman.com"
+./scripts/test_endpoints.sh "$BASE"
+```
+
 ## Wire into a GPT (Actions)
 Deploy this API and note the public HTTPS base URL.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,24 +1,24 @@
 openapi: 3.1.0
 info:
-  title: Tarot Action API
+  title: Diviaster Tarot Action API
   version: 1.0.0
 servers:
-  - url: https://YOUR-DOMAIN
+  - url: https://divia.pegasuswingman.com
 paths:
   /tarot/read:
     post:
       operationId: readTarot
-      summary: Deal a Celtic Cross and return the reading
+      summary: Deal a Celtic Cross spread and return a chat-ready reading
       requestBody:
         required: false
         content:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 seed:
                   type: string
-                  nullable: true
                 allowReversals:
                   type: boolean
                   default: true
@@ -30,13 +30,14 @@ paths:
               schema:
                 type: object
                 properties:
-                  spread: { type: object }
-                  analysis: { type: object }
-                  chat: { type: string }
+                  chat:
+                    type: string
+                  spread:
+                    type: object
   /tarot/last:
     get:
       operationId: lastTarot
-      summary: Get last dealt spread (if any)
+      summary: Get the last dealt spread/analysis
       responses:
         '200':
           description: OK
@@ -45,5 +46,21 @@ paths:
               schema:
                 type: object
                 properties:
-                  spread: { type: object }
-                  analysis: { type: object }
+                  chat:
+                    type: string
+                  spread:
+                    type: object
+        '204':
+          description: No content
+  /:
+    get:
+      operationId: health
+      summary: Health check
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ok

--- a/scripts/test_endpoints.sh
+++ b/scripts/test_endpoints.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE="${1:-http://localhost:8787}"
+
+echo "GET / (health)"
+curl -fsS -i "$BASE/"
+
+echo -e "\nPOST /tarot/read"
+curl -fsS -i -H "content-type: application/json" \
+  -X POST "$BASE/tarot/read" \
+  -d '{"allowReversals":true}'
+
+echo -e "\nGET /tarot/last"
+curl -fsS -i "$BASE/tarot/last"

--- a/server.js
+++ b/server.js
@@ -5,26 +5,51 @@ import { buildDeck, drawCelticCross, analyze, toChat } from "./src/tarot-core.js
 const app = express();
 app.use(cors());
 app.use(express.json());
+app.set("json spaces", 2);
+
+// basic structured logging
+app.use((req, res, next) => {
+  const start = Date.now();
+  res.on("finish", () => {
+    const duration = Date.now() - start;
+    console.log(
+      JSON.stringify({
+        time: new Date().toISOString(),
+        method: req.method,
+        path: req.originalUrl,
+        status: res.statusCode,
+        duration
+      })
+    );
+  });
+  next();
+});
 
 let __last = null;
 
-app.post("/tarot/read", (req, res)=>{
+app.post("/tarot/read", (req, res) => {
   const seed = req.body?.seed ?? null;
   const allowReversals = req.body?.allowReversals ?? true;
   const spread = drawCelticCross({ seed, allowReversals });
   const analysis = analyze(spread);
   const chat = toChat(spread, analysis);
-  __last = { spread, analysis };
-  res.json({ spread, analysis, chat });
+  const reading = { spread, analysis, chat };
+  __last = reading;
+  res.json(reading);
 });
 
-app.get("/tarot/last", (req,res)=>{
-  res.json(__last || {});
+app.get("/tarot/last", (req, res) => {
+  if (!__last) {
+    return res.status(204).end();
+  }
+  res.json(__last);
 });
 
-app.get("/", (req,res)=>{
-  res.type("text/plain").send("Tarot Action API is up.");
+app.get("/", (req, res) => {
+  res.type("text/plain").send("ok");
 });
 
 const port = process.env.PORT || 8787;
-app.listen(port, ()=> console.log(`Tarot Action API listening on :${port}`));
+app.listen(port, "0.0.0.0", () =>
+  console.log(`Tarot Action API listening on :${port}`)
+);


### PR DESCRIPTION
## Summary
- add structured request logging and 204 handling for missing tarot readings
- add health check and update routes to serve plain text "ok"
- document API and verification, provide OpenAPI 3.1 schema and test script

## Testing
- `./scripts/test_endpoints.sh http://localhost:8787`
- `./scripts/test_endpoints.sh https://divia.pegasuswingman.com` *(fails: 404)*

------
https://chatgpt.com/codex/tasks/task_e_689796f67e008330a8369b70cc071d54