### PR TITLE
fix: lowercase docker image tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute lowercase image tag
+        id: image
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY@L}:latest" >> "$GITHUB_OUTPUT"
       - uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ${{ steps.image.outputs.name }}

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -39,7 +39,7 @@ pnpm dev
 ## GitHub connector
 
 In ChatGPT, enable the GitHub connector and search
-`repo:1tsJeremiah/divia import` if the repo hasn't been indexed yet. This
+`repo:1tsjeremiah/divia import` if the repo hasn't been indexed yet. This
 forces a manual indexing pass.
 
 ## File search uploads


### PR DESCRIPTION
## Summary
- lower-case the repo owner in Docker image tags to satisfy GHCR naming rules
- update docs to use lower-case repo reference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899a20c243883309f71ac6c29dc7774